### PR TITLE
Fix build issues and add schedule schemas for Firebase deployment

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,17 +1,13 @@
 import type {Metadata} from 'next';
 import './globals.css';
 import { Toaster } from "@/components/ui/toaster"
-import { Inter } from 'next/font/google'
+
+export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
   title: 'K9 Trial Scoring System',
   description: 'A comprehensive system for managing and scoring K9 trials.',
 };
-
-const inter = Inter({
-  subsets: ['latin'],
-  display: 'swap',
-})
 
 export default function RootLayout({
   children,
@@ -19,7 +15,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning className={inter.className}>
+    <html lang="en" suppressHydrationWarning>
       <body className="antialiased">
         {children}
         <Toaster />

--- a/src/lib/schedule-types.ts
+++ b/src/lib/schedule-types.ts
@@ -72,8 +72,40 @@ export const ScheduledRunSchema = z.object({
     falseAlertPenalty: z.number().optional().nullable(),
     falseAlerts: z.number().optional().nullable(),
     startAt: z.custom<Timestamp>().optional().nullable(),
-    endAt: z.custom<Timestamp>().optional().nullable(),
+  endAt: z.custom<Timestamp>().optional().nullable(),
 });
 export type ScheduledEvent = z.infer<typeof ScheduledRunSchema>;
+
+export const InputSchema = z.object({
+  eventDays: z.array(z.string().regex(/^\d{4}-\d{2}-\d{2}$/)),
+  timeSlots: z.array(z.string().regex(/^\d{2}:\d{2}$/)),
+  arenas: z.array(ArenaSchema),
+  competitors: z.array(CompetitorSchema),
+});
+export type GenerateScheduleInput = z.infer<typeof InputSchema>;
+
+export const OutputSchema = z.object({
+  schedule: z.array(
+    z.object({
+      competitorId: z.string(),
+      arenaId: z.string(),
+      startTime: z.string().regex(/^\d{2}:\d{2}$/),
+      endTime: z.string().regex(/^\d{2}:\d{2}$/),
+      date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+    })
+  ),
+  diagnostics: z.object({
+    requiredRuns: z.number(),
+    placedRuns: z.number(),
+    unplacedRuns: z.array(
+      z.object({
+        competitorId: z.string(),
+        specialtyType: SpecialtyLabelSchema,
+        reason: z.string(),
+      })
+    ),
+  }),
+});
+export type GenerateScheduleOutput = z.infer<typeof OutputSchema>;
 
     


### PR DESCRIPTION
## Summary
- remove Google font dependency and force dynamic rendering to avoid build-time external calls
- add schedule input/output schemas for solver
- add minimal ESLint configuration

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0757493b48325a3248c3a7c48af03